### PR TITLE
fix for issue #43 where SUID use for source is more descriptive than …network name when creating subnetworks

### DIFF
--- a/R/Networks.R
+++ b/R/Networks.R
@@ -666,7 +666,7 @@ createSubnetwork <- function(nodes=NULL,
                              subnetwork.name=NULL,
                              network = NULL,
                              base.url = .defaultBaseUrl) {
-    title = getNetworkName(network, base.url)
+    title = getNetworkSuid(network, base.url)
     
     if (exclude.edges) 
         exclude.edges = "true"
@@ -680,7 +680,7 @@ createSubnetwork <- function(nodes=NULL,
         edges.by.col = NULL
     
     json_sub = NULL
-    json_sub$source = title
+    json_sub$source = paste0("SUID:", title)
     json_sub$excludeEdges = exclude.edges
     json_sub$nodeList = .prepPostQueryLists(nodes,nodes.by.col)
     json_sub$edgeList = .prepPostQueryLists(edges,edges.by.col)


### PR DESCRIPTION
Simple fix for this issue. Previously if there were several networks with the same name the new subnetwork would always be set as a subnetwork of the first network with the name even if the subnetwork originated from the 2nd (or 3rd, etc) network with the same name. 